### PR TITLE
Add Link For Facebook Sharer

### DIFF
--- a/wp-event-manager-template.php
+++ b/wp-event-manager-template.php
@@ -682,6 +682,7 @@ function display_event_banner( $size = 'full', $default = null, $post = null ) {
 				
 			$banner = event_manager_get_resized_image( $banner, $size );
 		}
+		echo '<link rel="image_src" href="' . esc_attr( $banner ) . '"/>';
 		echo '<img itemprop="image" content="' . esc_attr( $banner ) . '" src="' . esc_attr( $banner ) . '" alt="' . esc_attr( get_organizer_name( $post ) ) . '" />';
 
 	} else if ( $default ) {


### PR DESCRIPTION
Currently, when sharing an event, the Facebook Sharer picks a random image from the website. This can lead into unwanted results as in our case an advertisement image is selected.

This fix adds an `<link rel="..." />` into the event body telling the Facebook sharer to use the correct event image.