### PR TITLE
Add event_manager_get_permalink filter

### DIFF
--- a/wp-event-manager-functions.php
+++ b/wp-event-manager-functions.php
@@ -1311,7 +1311,14 @@ function event_manager_get_page_id( $page )
 function event_manager_get_permalink( $page ) {
 
 	if ( $page_id = event_manager_get_page_id( $page ) ) {
-		return get_permalink( $page_id );
+        /**
+         * Filters the permalink of a page if set in the options
+         * 
+         * @param string $permalink the permalink of the page
+         * @param int $page_id the page id like it's stored in the options
+         * @param string $page the pages internal name e.g. event_dashboard, submit_event_form, events
+         */
+		return apply_filters('event_manager_get_permalink', get_permalink( $page_id ), $page_id, $page );
 	} else {
 		return false;
 	}


### PR DESCRIPTION
Example use case: I have a single "my-account" page that contains all of the dashboards, accessible via tabs and subpaths like ".../my-account/organizer". I want to set the organizer_dashboard permalink to ".../my-account/organizer", but that's not possible, because it is not its own page.

Maybe it would be better to change how the options work, so you can set either a page id or a permalink in the settings, but that would be a lot of work. So this filter just gives developers something to work with.