### PR TITLE
Update wp-event-manager-writepanels.php

### DIFF
--- a/admin/wp-event-manager-writepanels.php
+++ b/admin/wp-event-manager-writepanels.php
@@ -1247,6 +1247,8 @@ class WP_Event_Manager_Writepanels {
 						if(!empty($_POST[$key])) {
 							$v_text = wp_kses_post(stripslashes($_POST[$key]));
 							update_post_meta($post_id, sanitize_key($key), $v_text);
+						}else{
+							update_post_meta($post_id, sanitize_key($key), '');
 						}
 						break;
 					default:


### PR DESCRIPTION
<img width="3382" height="345" alt="custom event field" src="https://github.com/user-attachments/assets/76e1e8f9-f87a-485a-b06e-0de7ea56e6f4" />

This fixes a bug that prevents you from deleting the contents of an additional field of type WP Editor.  As the code stands, you can create an additional field of type WP Editor and add or edit the detail in that field.  But if you later have no need for that extra field on an event, you can't clear the field because the current code doesn't have any provision to do this.  This small update fixes that bug.

To replicate the issue, create an additional field of type WP Editor.  Then go to an event and add some detail to that additional field and save/publish the event.  Now go back to that event and try to delete the contents of that additional field.

