### PR TITLE
Update wp-event-manager-shortcodes.php

### DIFF
--- a/shortcodes/wp-event-manager-shortcodes.php
+++ b/shortcodes/wp-event-manager-shortcodes.php
@@ -1106,7 +1106,8 @@ class WP_Event_Manager_Shortcodes{
 		), $atts);
 
 		$paged = (get_query_var('paged')) ? absint(get_query_var('paged')) : 1;
-
+		$show_pagination = sanitize_text_field($atts['show_pagination']);
+		$per_page = sanitize_text_field($atts['per_page']);
 		$args_past = array(
 			'post_type'      => 'event_listing',
 			'post_status'    => array('expired'),


### PR DESCRIPTION
Fixes lack of pagination on past events.  

Pagination is not working on past events.  This is because two variables have not been initialised as per the following errors:

```
[19-Aug-2025 15:54:26 UTC] PHP Warning: Undefined variable $per_page in /wp-content/plugins/wp-event-manager/shortcodes/wp-event-manager-shortcodes.php on line 1207
[19-Aug-2025 15:54:26 UTC] PHP Warning: Undefined variable $show_pagination in /wp-content/plugins/wp-event-manager/shortcodes/wp-event-manager-shortcodes.php on line 1208
```

This pull request fixes this issue.