### PR TITLE
Update wp-event-manager-shortcodes.php for upcoming events

### DIFF
--- a/shortcodes/wp-event-manager-shortcodes.php
+++ b/shortcodes/wp-event-manager-shortcodes.php
@@ -1685,6 +1685,7 @@ class WP_Event_Manager_Shortcodes{
 		$per_page = $atts['per_page'];
 		$layout_type = $atts['layout_type'];
 		$title = $atts['title'];
+		$show_pagination = $atts['show_pagination'];
 
 		$args = array(
 			'post_type'       => 'event_listing',


### PR DESCRIPTION
Fix for missing pagination on upcoming events page.  Variable $show_pagination has not been initialised in the function output_upcoming_events($atts)

Tested with 
`[upcoming_events per_page="5" orderby="event_start_date" order="ASC" show_filters="false" layout_type="box" show_pagination="true"]
`
Without the fix you can only see 'Load more listings' on the page, regardless of how pagination is set.