### PR TITLE
Proper fix to expiry dates on events and the actual expiry implementation.

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -221,7 +221,6 @@ var Admin = function () {
             if (jQuery('input[name=_event_ticket_options]:checked').length > 0) {
                 jQuery('input[name=_event_ticket_options]:checked').trigger('change');
             }
-            jQuery('body').on('change', '#_event_end_date', Admin.actions.setListingExpery);
 
              //upgrade database
              jQuery("#shortcode_list_filter_action").on('click', Admin.actions.getShortcodeList);
@@ -337,21 +336,6 @@ var Admin = function () {
                             jQuery('._event_health_guidelines').closest('.form-field').hide();
                             jQuery('[name="_enable_health_guideline_other"]').closest('.form-field').hide();
                             jQuery('input[name="_enable_health_guideline_other"][value="no"]').prop('checked', true).trigger('change');
-                        }
-                    },
-
-                    /// <summary>
-                    /// Set listing expiry
-                    /// </summary>
-                    /// <returns type="initialization settings" />
-                    /// <since>3.1.16</since>
-                    setListingExpery: function (event) {
-                        event.preventDefault();
-                        var endDate = jQuery(this).val();
-                        var expiryDate = jQuery('#_event_expiry_date').val();
-
-                        if (expiryDate === '') {
-                            jQuery('#_event_expiry_date').val(endDate);
                         }
                     },
 

--- a/assets/js/admin.min.js
+++ b/assets/js/admin.min.js
@@ -221,7 +221,6 @@ var Admin = function () {
             if (jQuery('input[name=_event_ticket_options]:checked').length > 0) {
                 jQuery('input[name=_event_ticket_options]:checked').trigger('change');
             }
-            jQuery('body').on('change', '#_event_end_date', Admin.actions.setListingExpery);
 
              //upgrade database
              jQuery("#shortcode_list_filter_action").on('click', Admin.actions.getShortcodeList);
@@ -337,21 +336,6 @@ var Admin = function () {
                             jQuery('._event_health_guidelines').closest('.form-field').hide();
                             jQuery('[name="_enable_health_guideline_other"]').closest('.form-field').hide();
                             jQuery('input[name="_enable_health_guideline_other"][value="no"]').prop('checked', true).trigger('change');
-                        }
-                    },
-
-                    /// <summary>
-                    /// Set listing expiry
-                    /// </summary>
-                    /// <returns type="initialization settings" />
-                    /// <since>3.1.16</since>
-                    setListingExpery: function (event) {
-                        event.preventDefault();
-                        var endDate = jQuery(this).val();
-                        var expiryDate = jQuery('#_event_expiry_date').val();
-
-                        if (expiryDate === '') {
-                            jQuery('#_event_expiry_date').val(endDate);
                         }
                     },
 

--- a/includes/wp-event-manager-post-types.php
+++ b/includes/wp-event-manager-post-types.php
@@ -42,11 +42,7 @@ class WP_Event_Manager_Post_Types {
 		add_action('event_manager_check_for_expired_events', array($this, 'check_for_expired_events'));
 		add_action('event_manager_delete_old_previews', array($this, 'delete_old_previews'));
 
-		add_action('pending_to_publish', array($this, 'set_event_expiry_date'));
-		add_action('preview_to_publish', array($this, 'set_event_expiry_date'));
-		add_action('draft_to_publish', array($this, 'set_event_expiry_date'));
-		add_action('auto-draft_to_publish', array($this, 'set_event_expiry_date'));
-		add_action('expired_to_publish', array($this, 'set_event_expiry_date'));
+		add_action('publish_event_listing', array($this, 'set_event_expiry_date'));
 		
 		add_action('wp_footer', array($this, 'output_structured_data'));
 		
@@ -678,7 +674,9 @@ class WP_Event_Manager_Post_Types {
 		if($event_ids) {
 			foreach ($event_ids as $event_id) {
 				$event = get_post($event_id);
-				$expiry_date = apply_filters('wpem_expire_date_time', date('Y-m-d H:i:s', strtotime(esc_html(get_post_meta($event_id, '_event_expiry_date', true)). ' 23:59:30')), $event);     
+				$end_time = get_post_meta( $event_id, '_event_end_time',true );
+				$expiry_date = get_post_meta( $event_id, '_event_expiry_date',true );
+				$expiry_date = apply_filters('wpem_expire_date_time', date('Y-m-d H:i:s', strtotime($expiry_date . ' ' . $end_time)), $event);     
 				$today_date = apply_filters('wpem_get_current_expire_time', date('Y-m-d H:i:s', current_time('timestamp')));     
 				
 				// Check for event expire    
@@ -764,31 +762,26 @@ class WP_Event_Manager_Post_Types {
 	/**
 	 * Set expirey date when event status changes.
 	 */
-	public function set_event_expiry_date($post) {
-		if($post->post_type !== 'event_listing') {
-			return;
-		}
-		// See if it is already set
-		if(metadata_exists('post', $post->ID, '_event_expiry_date')) {
-			$expires = esc_html(get_post_meta($post->ID, '_event_expiry_date', true));
-			if($expires && strtotime($expires) < current_time('timestamp')) {
-				update_post_meta($post->ID, '_event_expiry_date', sanitize_text_field(''));
-			}
-		}
+	public function set_event_expiry_date($postID) {
+
+		$post = get_post($postID);
 		
-		// No metadata set so we can generate an expiry date
 		// See if the user has set the expiry manually:
 		if(!empty($_POST[ '_event_expiry_date' ])) {
-			update_post_meta($post->ID, '_event_expiry_date', date('Y-m-d', strtotime(wp_kses_post($_POST[ '_event_expiry_date' ]))));
-			// No manual setting? Lets generate a date
-		} elseif(false == isset($expires)){
-			$expires = get_event_expiry_date($post->ID);
-			update_post_meta($post->ID, '_event_expiry_date', sanitize_text_field($expires));
-			// In case we are saving a post, ensure post data is updated so the field is not overridden
-			if(isset($_POST[ '_event_expiry_date' ])) {
-				$_POST[ '_event_expiry_date' ] = $expires;
+			$expires = $_POST[ '_event_expiry_date' ];
+			if(!metadata_exists('post', $post->ID, '_event_expiry_date')) {
+				// expiry date is empty in db so let's update the event
+				update_post_meta($post->ID, '_event_expiry_date', $expires);
 			}
+			return;
+			
+		} else {  // No manual setting? Lets generate a date
+			$expires = get_event_expiry_date($post->ID);
+
+            update_post_meta($post->ID, '_event_expiry_date', $expires);
+
 		}
+		return;
 	}
 
 	/**

--- a/wp-event-manager-functions.php
+++ b/wp-event-manager-functions.php
@@ -1325,12 +1325,14 @@ function get_event_expiry_date($event_id) {
 	//get set listing expiry time duration
 	$option=get_option('event_manager_submission_expire_options');
 	$event_start_date = esc_attr(get_post_meta($event_id, '_event_start_date', true));
+	$event_start_date = substr($event_start_date, 0, 10);  // strip off any time from end of date
 	$event_end_date = esc_attr(get_post_meta($event_id, '_event_end_date', true));
+	$event_end_date = substr($event_end_date, 0, 10);  // strip off any time from end of date
+
 	$expiry_base_date = $event_end_date ? $event_end_date : $event_start_date;
 
 	if($option==='event_end_date')	{
-		if($expiry_base_date)
-			return date('Y-m-d', strtotime($expiry_base_date));
+			return $expiry_base_date;
 	} else {
 		// Get duration from the admin settings if set.
 		$duration = esc_attr(get_post_meta($event_id, '_event_duration', true));		
@@ -1338,10 +1340,11 @@ function get_event_expiry_date($event_id) {
 		if(!$duration) {		   
 			$duration = absint(get_option('event_manager_submission_duration'));
 		}
-		if($duration) 
+
+		if($duration) {
 			return date('Y-m-d', strtotime("+{$duration} days", strtotime($expiry_base_date)));
+		}
 	}
-	return '';
 }
 
 /**


### PR DESCRIPTION
### **Getting the expiry date to autocomplete**
The original concept for expiring events was perfectly sound. It just wasn't implemented very well. Under Event Manager > Settings > Event Submission is a setting called 'Listing Expire'.
The default looks like this:
<img width="1870" height="170" alt="image" src="https://github.com/user-attachments/assets/fc1447ae-a1d0-4504-b09a-abe4f4687bdb" />

or you can select to expire after a certain number of days.
<img width="1875" height="395" alt="image" src="https://github.com/user-attachments/assets/6a1633ec-2b23-4499-a85b-76d2fc7bd359" />

This should have been the end of it, but unfortunately, the code that is supposed to act on this doesn't work. It doesn't work because the code that's supposed to work out the expiry date has bugs, and because that code is being called by an ineffective trigger.

Unless an event expiry date is actually set on an event it will never expire. That's why some code was added to ensure that the expiry date on an event was always completed after publishing the event, unless of course the above 'Listing Duration' is blank. On saving or publishing an event the code should check to see if the expiry date is empty, and if it is, it uses the 'Listing Expire' setting to work out what the expiry day should be.

First of all the abomination of a so called 'fix' in Version 3.1.51 of Event Manager needs to be removed. I can't understand this obsession with some of your developers to make the expiry date the same as the end date, regardless of the users wishes.

Having removed the offending so called 'fix' we can work on the real issues within the original code. There are two parts to this. First the function that attempts to generate an expiry date if none exists on the post. This can be found in the wp-event-manager-functions.php file in the root of the plugin. The function, get_event_expiry_date(), as it stands just doesn't work as it should.

If 'Listing Duration' in settings is blank, then this function returns nothing and so the expiry date remains blank. The function that calls the above function can be found in the wp-event-manager-post-types.php file, which is in the includes folder of the plugin. This function is called set_event_expiry_date(). The existing function, is as usual, over complicated and doesn't always give the desired results.

Now we come to the interesting part. The bit that actually calls the above set_event_expiry_date() function. This can be found further up the same file in a set of triggers, as follows:

```
	add_action('pending_to_publish', array($this, 'set_event_expiry_date'));
	add_action('preview_to_publish', array($this, 'set_event_expiry_date'));
	add_action('draft_to_publish', array($this, 'set_event_expiry_date'));
	add_action('auto-draft_to_publish', array($this, 'set_event_expiry_date'));
	add_action('expired_to_publish', array($this, 'set_event_expiry_date'));
```

Unfortunately none of these will ever work. Whether they ever worked is a mute point, but they certainly don't now. These are called 'transition hooks', and as the name suggests, they capture the post from one state to another. An undocumented feature of these particular hooks is that you cannot make changes to the post being published, at this point. You can send an email or change anything else, but not the post that's being transitioned to the publish state. What happens is this: no matter what you change in the post, when the publish resumes, it picks up from where it left off and overwrites any changes you made with what Wordpress has in cache for that post. So it resets the expiry date to whatever it was before, which of course would usually be nothing. The correct hook to use is the {status}_{post_type} one. Delete the 5 lines above and replace with:

`	add_action('publish_event_listing', array($this, 'set_event_expiry_date'));`

Because this hook only targets event listings, there's no need to check the post type in the set_event_expiry_date() function.

Job done. This trigger works on publish and update. So if you create an event and complete the expiry date field, nothing changes. If you leave the field blank it will be completed automatically by the above code. That is unless you have the 'Listing Duration' blank in your settings. This is how it was always intended to work. If you don't have the 'Listing Duration' blank in your settings and you want individual events to never expire, you simply need to set an expiry date on that event that is well into the future. I use '31/12/9998'.

The last update is to the check_for_expired_events() function in the wp-event-manager-post-types.php file. The expiry date has no time associate with it, so when you check an event to see if it needs to be expired, you add the time of 23:59:30. So if an event finishes at say 11am, it still shows on the calendar and events page as an active event. I don't think this is desirable. So instead of adding 23:59:30 to the expiry date, I've added the end time. I've made a simple change to the loop that checks events to be expired in the check_for_expired_events() function. I believe this is what people might really expect when they select events to expire on the end date. Also it makes more sense of the cron job that checks for expired events every hour. Without this last update there'd be no need to run the cron job more than once a day.