### PR TITLE
Update wp-event-manager-functions.php

### DIFF
--- a/wp-event-manager-functions.php
+++ b/wp-event-manager-functions.php
@@ -2342,3 +2342,114 @@ function wpem_get_form_field_types() {
 		)
 	);
 }
+
+/**
+ * Removes WP date filter on event listing in admin area
+ * which filters on publish date not start date of event.
+ */
+add_filter('months_dropdown_results', 'disable_default_date_filters_robust', 10, 2 );
+function disable_default_date_filters_robust( $months, $post_type ) {
+    if ( $post_type == 'event_listing' ) {
+        return array(); // Return an empty array to remove the default date filter
+    }
+    return $months; // Return the original months if not our post type
+}
+
+/**
+ * Set up a new date filter on event listing in admin area.
+ */
+function custom_date_filter_form() {
+    global $wpdb;	
+    $selected_month = get_custom_date_filter_from_get(); // Get the selected month
+    $results = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT DISTINCT SUBSTRING(pm.meta_value, 1, 7) AS event_month_year
+            FROM {$wpdb->posts} p
+            INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
+            WHERE p.post_type = %s
+            AND pm.meta_key = %s
+            AND pm.meta_value IS NOT NULL
+            ORDER BY event_month_year ASC", // Order by year-month for correct chronological order
+            'event_listing',
+            '_event_start_date'
+        )
+    );
+
+    $dateList = array();
+    foreach ( $results as $result ) {
+        // $result->event_month_year will be in YYYY-MM format (e.g., '2025-07')
+		$selector = $result->event_month_year;
+        $year = substr( $result->event_month_year, 0, 4 );
+        $month_num = substr( $result->event_month_year, 5, 2 );
+        $month_name = date( "F", mktime( 0, 0, 0, (int) $month_num, 10 ) );
+        $dateList[ $selector ] = $month_name . ' ' . $year; // Store as month number => Month Name Year
+    }
+	
+    $html = '<select name="custom_date_filter">';
+    $html .= '<option value="">All Dates</option>';
+
+    foreach ( $dateList as $month_num => $month_name_year ) {
+        $selected = ( $selected_month == $month_num ) ? 'selected="selected"' : '';
+        $html .= '<option value="' . esc_attr( $month_num ) . '" ' . $selected . '>' . esc_html( $month_name_year ) . '</option>';
+    }
+
+    $html .= '</select>';
+    return $html;  // Return the complete HTML string
+}
+
+
+/**
+ * Get the relevant event listings to display.
+ */
+function filter_by_custom_date($query) {
+    global $pagenow, $wpdb;
+	$selected_month = get_custom_date_filter_from_get();
+	$post_type = get_post_type_from_get();
+    if ($pagenow === 'edit.php' && isset($post_type) && $post_type == 'event_listing' && isset($selected_month)) {
+        $date_filter = $selected_month;
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		if($date_filter == ""){
+			$sql = 
+				"SELECT p.ID
+				FROM {$wpdb->posts} p
+				INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
+				WHERE p.post_type = %s
+				";
+			$sql = $wpdb->prepare($sql, 'event_listing');
+			$post_ids = $wpdb->get_col( $sql );
+		}else{
+				$sql = 
+				"SELECT p.ID
+				FROM {$wpdb->posts} p
+				INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
+				WHERE p.post_type = %s
+				AND pm.meta_key = %s
+				AND SUBSTRING(pm.meta_value, 1, 7) = %s
+				";
+			$sql = $wpdb->prepare($sql, 'event_listing', '_event_start_date', $date_filter);
+			$post_ids = $wpdb->get_col( $sql ); // Get post IDs that match
+		}
+        if ( ! empty( $post_ids ) ) {
+            $query->set( 'post__in', $post_ids ); // Set post__in to filter by those IDs
+            $query->set( 'orderby', 'post__in' ); // Maintain original order
+        } else {
+            $query->set( 'post__in', array(0) ); // No results, use a non-existent ID to prevent results
+        }
+    }
+	return $query;
+}
+add_filter('pre_get_posts', 'filter_by_custom_date');
+
+function get_custom_date_filter_from_get() {
+    $month = filter_input( INPUT_GET, 'custom_date_filter', FILTER_SANITIZE_NUMBER_INT );
+    return $month;
+}
+
+function get_post_type_from_get() {
+    $post_type = filter_input( INPUT_GET, 'post_type', FILTER_SANITIZE_STRING );
+    return $post_type;
+}
+
+add_filter( 'restrict_manage_posts', function($html) {
+    printf('%s', custom_date_filter_form()); // Return the result of the function, as intended.
+}, 10 );


### PR DESCRIPTION
The existing event listing in the admin panel does not filter by date correctly for events. The filter is designed for ordinary posts that have no concept of a start or end date and currently only offers the publish date for filtering.

<img width="1952" height="415" alt="490661353-ded02d48-da88-42a6-a309-846e5211c874" src="https://github.com/user-attachments/assets/c9cbc5c9-bed4-4ea1-a7f9-6f590e68e467" />

Ideally you'd want to filter by start date. for events. This update does just that.

<img width="2512" height="642" alt="490666490-52f0922e-b7a1-4177-81d3-373172e0c13e" src="https://github.com/user-attachments/assets/58513c46-4abd-4d7c-9128-cc42158915ed" />

The new code identifies all events with a valid start date and creates a unique dropdown for each month-year.  Selecting a month-year and hitting the filter button will bring back just the events with the corresponding month-year start date.