### PR TITLE
Fix ReferenceError: target is not defined in loadMoreUpcomingEvents

### DIFF
--- a/assets/js/event-ajax-filters.js
+++ b/assets/js/event-ajax-filters.js
@@ -432,7 +432,7 @@ var EventAjaxFilters = function() {
                             per_page: per_page,
                         },
                         success: function(response) {
-                            target.find('.load_more_events_loader').removeClass('wpem-loading');
+                            jQuery('#upcoming_event_listing').find('#load_more_events_loader, .load_more_events_loader').removeClass('wpem-loading');
                             if (response.success) {
                                 jQuery('.event_listings').append(response.data.events_html);                            
                                 var nextPage = parseInt(currentPage) + 1;

--- a/assets/js/event-ajax-filters.min.js
+++ b/assets/js/event-ajax-filters.min.js
@@ -432,7 +432,7 @@ var EventAjaxFilters = function() {
                             per_page: per_page,
                         },
                         success: function(response) {
-                            target.find('.load_more_events_loader').removeClass('wpem-loading');
+                            jQuery('#upcoming_event_listing').find('#load_more_events_loader, .load_more_events_loader').removeClass('wpem-loading');
                             if (response.success) {
                                 jQuery('.event_listings').append(response.data.events_html);                            
                                 var nextPage = parseInt(currentPage) + 1;


### PR DESCRIPTION
### Summary
Fixes a JavaScript \ReferenceError: target is not defined\ when using the upcoming events shortcode with Load more pagination.

### Root cause
\loadMoreUpcomingEvents\ referenced \	arget\ in the AJAX success handler (copied from \getEventListings\), but \	arget\ is never defined in that function.

### What changed
Use a jQuery lookup on \#upcoming_event_listing\ and the loader (\#load_more_events_loader\ / \.load_more_events_loader\) to clear \wpem-loading\ without throwing.

### Files
- \ssets/js/event-ajax-filters.js\
- \ssets/js/event-ajax-filters.min.js\